### PR TITLE
Use serverless' getStackName() api

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ class CloudfrontInvalidate {
       credentials: awsCredentials.credentials,
       region: this.serverless.getProvider('aws').getRegion()
     });
-    const stackName = `${this.serverless.service.getServiceName()}-${this.serverless.getProvider('aws').getStage()}`
+    const stackName = this.serverless.getProvider('aws').naming.getStackName()
 
     return cfn.describeStacks({ StackName: stackName }).promise()
       .then(result => {


### PR DESCRIPTION
It looks like to me this API was [implemented in serverless version 1.28](https://github.com/serverless/serverless/pull/4951)

Let me know if you have questions, thanks for making this plugin available! Cheers.

Fixes #11