### PR TITLE
feat: Add multiple invalidations based on stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ custom:
       items: # one or more paths required
         - "/index.html"
       stage: "dev"  # conditional, the stage that this cloudfront invalidation should be created
-            # this should match the provider's stage you declared, e.g. "dev" but not "development" in this case
+            # this should match the provider's stage you declared, e.g. "dev" but not "prod" in this case
             # an invalidation for this distribution will be created when executing `sls deploy --stage dev`
     - distributionId: "CLOUDFRONT_DIST_ID" #conditional, distributionId or distributionIdKey is required.
       distributionIdKey: "CDNDistributionId" #conditional, distributionId or distributionIdKey is required.

--- a/README.md
+++ b/README.md
@@ -24,10 +24,18 @@ If the CDN is created as part of same serverless.yml then you can specify the `d
 ```yaml
 custom:
   cloudfrontInvalidate:
-    distributionId: "CLOUDFRONT_DIST_ID" #conditional, distributionId or distributionIdKey is required.
-    distributionIdKey: "CDNDistributionId" #conditional, distributionId or distributionIdKey is required.
-    items: # one or more paths required
-      - "/index.html"
+    - distributionId: "CLOUDFRONT_DIST_ID" #conditional, distributionId or distributionIdKey is required.
+      distributionIdKey: "CDNDistributionId" #conditional, distributionId or distributionIdKey is required.
+      items: # one or more paths required
+        - "/index.html"
+      stage: "dev"  # conditional, the stage that this cloudfront invalidation should be created
+            # this should match the provider's stage you declared, e.g. "dev" but not "development" in this case
+            # an invalidation for this distribution will be created when executing `sls deploy --stage dev`
+    - distributionId: "CLOUDFRONT_DIST_ID" #conditional, distributionId or distributionIdKey is required.
+      distributionIdKey: "CDNDistributionId" #conditional, distributionId or distributionIdKey is required.
+      items: # one or more paths required
+        - "/index.html"
+      # `stage` is omitted, an invalidation will be created for this distribution at all stages
 resources:
   Resources:
     CDN:


### PR DESCRIPTION
Before this PR, `cloudfrontInvalidation` was a single object under the `custom` section of serverless.yml file. There was no possible way to create invalidations for multiple CloudFront distributions. Therefore, the `cloudfrontInvalidation` object is turned into a list that can contain multiple distributions. The index.js file is modified to realize this feature. The function body in `invalidate()` is moved into `...cloudfrontInvalidation.forEach()`. This feature is also mentioned in issue #8.

Besides, an option of create invalidations based on deployment stages was also not available. Hence, an optional `stage` property is added for each distribution element. An if statement that checks for `stage` property declaration and its matching with the provider's stage is added into `invalidate()` in index.js file.

The Setup example of `cloudfrontInvalidation` as a list and the Setup example of using the `stage` property of the elements of `cloudfrontInvalidation` is added to README.md file.