### PR TITLE
support serverless' --noDeploy option

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,6 +91,10 @@ class CloudfrontInvalidate {
 
   invalidate() {
     const cli = this.serverless.cli;
+    if (this.options.noDeploy) {
+      cli.consoleLog('skipping invalidation due to noDeploy option');
+      return;
+    }
     let cloudfrontInvalidate = this.serverless.service.custom.cloudfrontInvalidate;
     let reference = randomstring.generate(16);
     let distributionId = cloudfrontInvalidate.distributionId;


### PR DESCRIPTION
Skips invalidations on deploy if the serverless --noDeploy option was specified. This option is currently supported by the [AWS provider `deploy` command](https://github.com/serverless/serverless/blob/8c4d97211aa3dd4c41d9205a3ca0ccaab3564225/lib/plugins/aws/deploy/index.js#L90). Apparently there was intent to deprecate it in favour of the `package` command (see https://github.com/serverless/serverless/issues/3510), but that hasn't happened yet.