### PR TITLE
Add autoInvalidate prop to the cloudfrontInvalidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ custom:
     distributionIdKey: "CDNDistributionId" #conditional, distributionId or distributionIdKey is required.
     items: # one or more paths required
       - "/index.html"
+    autoInvalidate: true # Can be set to false to avoid automatic invalidation after the deployment. Useful if you want to manually trigger the invalidation later. Defaults to true.
 resources:
   Resources:
     CDN:

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You can communicate with AWS even if you are using a proxy by setting the proxy 
   - HTTPS_PROXY
   - https_proxy
 
-- exsample
+- example
 
   windows: `set HTTP_PROXY=http://localhost:8080`
 

--- a/index.js
+++ b/index.js
@@ -38,9 +38,12 @@ class CloudfrontInvalidate {
     };
 
     this.hooks = {
-      'after:deploy:deploy': this.invalidate.bind(this),
       'cloudfrontInvalidate:invalidate': this.invalidate.bind(this),
     };
+
+    if (serverless.service.custom.cloudfrontInvalidate.autoInvalidate !== false) {
+      this.hooks['after:deploy:deploy'] = this.invalidate.bind(this)
+    }
   }
 
   setProxy(proxyURL) {
@@ -82,7 +85,7 @@ class CloudfrontInvalidate {
         cli.consoleLog(`CloudfrontInvalidate: ${chalk.yellow('Invalidation started')}`);
       },
       err => {
-        console.log(JSON.stringify(err));
+        cli.consoleLog(JSON.stringify(err));
         cli.consoleLog(`CloudfrontInvalidate: ${chalk.yellow('Invalidation failed')}`);
         throw err;
       }


### PR DESCRIPTION
I've added this functionality as our CI deployment script has the following steps:

1. Deploy the stack using `serverless`
2. Push static files to s3 bucket
3. Invalidate CloudFront

This PR adds the ability to avoid invalidating CloudFront on the first step, preventing double invalidation.